### PR TITLE
nix: Update for new directory structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ all: $(foreach pkg,$(lwce_packages),$(BUILDDIR)/$(pkg).u)
 $(engine_conf).default: $(SRCDIR)/wine_build $(UDK)
 	bash $(SRCDIR)/wine_build init_wpfx "$(UDK)" "$(UDK_SRCPATH)" "$(engine_conf)" "$(engine_conf).default"
 
-$(engine_conf): $(SRCDIR)/wine_build $(engine_conf).default $(SRCDIR)/Stubs $(SRCDIR)/Src
-	bash $(SRCDIR)/wine_build lwce_udk "$(UDK_SRCPATH)" "$(SRCDIR)" "$(engine_conf).default" "$(engine_conf)" $(ew_stub_packages) $(lwce_stub_packages) $(lwce_packages)
+$(engine_conf): $(SRCDIR)/wine_build $(engine_conf).default $(SRCDIR)/Stubs $(SRCDIR)/LWCE_Core/Src
+	bash $(SRCDIR)/wine_build lwce_udk "$(UDK_SRCPATH)" "$(SRCDIR)/Stubs" "$(SRCDIR)/LWCE_Core/Src" "$(engine_conf).default" "$(engine_conf)" $(ew_stub_packages) $(lwce_stub_packages) $(lwce_packages)
 
 udk_rebuild:
 
@@ -36,11 +36,12 @@ $(BUILDDIR)/%.u: $(SRCDIR)/wine_build $(engine_conf) udk_rebuild
 	bash $(SRCDIR)/wine_build lwce_build "$(WINE_UDK)"
 	cp "$(WINE_UDK)/UDKGame/Script/$(notdir $@)" "$@"
 
-install: $(wildcard Config/* Localization/* Patches/* README*) all
-	mkdir -p "$(DESTDIR)"/{CookedPCConsole,Config,Localization}
+install: $(wildcard LWCE_Core/Config/* LWCE_Core/Localization/*/* LWCE_Core/Patches/* README*) all
+	mkdir -p "$(DESTDIR)"/{Config,CookedPCConsole,Localization/INT,UPK\ patches}
 	$(foreach pkg,$(lwce_packages),cp "$(BUILDDIR)/$(pkg).u" "$(DESTDIR)/CookedPCConsole")
-	for f in Config/* Localization/*; do unix2dos <"$$f" >"$(DESTDIR)/$$f"; done
-	unix2dos <Patches/XComGame_Overrides.upatch > "$(DESTDIR)/LWCE_Install.txt"
+	for f in "LWCE_Core/Config"/*; do unix2dos <"$$f" >"$(DESTDIR)/Config/$${f##*/}"; done
+	for f in "LWCE_Core/Localization/INT"/*; do unix2dos <"$$f" >"$(DESTDIR)/Localization/INT/$${f##*/}"; done
+	for f in "LWCE_Core/Patches"/*; do unix2dos <"$$f" >"$(DESTDIR)/UPK patches/$${f##*/}"; done
 	unix2dos <README_installation.txt > "$(DESTDIR)/README.txt"
 
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ DESTDIR = install
 ew_stub_packages = Core Engine GFxUI
 lwce_stub_packages = XComGame XComStrategyGame XComUIShell XComMutator XComLZMutator
 lwce_packages = XComLongWarCommunityEdition
+lwce_mods = LWCEGraphicsPack
 
 
 WPFX = $(BUILDDIR)/wpfx
@@ -22,23 +23,29 @@ export WINEPREFIX=$(abspath $(WPFX))
 export WINEARCH=win32
 export WINEDEBUG=fixme-all,trace-all
 
-all: $(foreach pkg,$(lwce_packages),$(BUILDDIR)/$(pkg).u)
+all: $(foreach pkg,$(lwce_packages) $(lwce_mods),$(BUILDDIR)/$(pkg).u)
 
 $(engine_conf).default: $(SRCDIR)/wine_build $(UDK)
 	bash $(SRCDIR)/wine_build init_wpfx "$(UDK)" "$(UDK_SRCPATH)" "$(engine_conf)" "$(engine_conf).default"
 
 $(engine_conf): $(SRCDIR)/wine_build $(engine_conf).default $(SRCDIR)/Stubs $(SRCDIR)/LWCE_Core/Src
-	bash $(SRCDIR)/wine_build lwce_udk "$(UDK_SRCPATH)" "$(SRCDIR)/Stubs" "$(SRCDIR)/LWCE_Core/Src" "$(engine_conf).default" "$(engine_conf)" $(ew_stub_packages) $(lwce_stub_packages) $(lwce_packages)
+	bash $(SRCDIR)/wine_build lwce_udk "$(UDK_SRCPATH)" \
+		"$(engine_conf).default" "$(engine_conf)" \
+		$(foreach pkg,$(ew_stub_packages),"$(SRCDIR)/Stubs/$(pkg)") \
+		$(foreach pkg,$(lwce_stub_packages),"$(SRCDIR)/Stubs/$(pkg)") \
+		$(foreach pkg,$(lwce_packages),"$(SRCDIR)/LWCE_Core/Src/$(pkg)") \
+		$(foreach pkg,$(lwce_mods),"$(SRCDIR)/LWCE_BundledMods/$(pkg)/Src/$(pkg)") \
+
 
 udk_rebuild:
+	bash $(SRCDIR)/wine_build lwce_build "$(WINE_UDK)"
 
 $(BUILDDIR)/%.u: $(SRCDIR)/wine_build $(engine_conf) udk_rebuild
-	bash $(SRCDIR)/wine_build lwce_build "$(WINE_UDK)"
 	cp "$(WINE_UDK)/UDKGame/Script/$(notdir $@)" "$@"
 
 install: $(wildcard LWCE_Core/Config/* LWCE_Core/Localization/*/* LWCE_Core/Patches/* README*) all
 	mkdir -p "$(DESTDIR)"/{Config,CookedPCConsole,Localization/INT,UPK\ patches}
-	$(foreach pkg,$(lwce_packages),cp "$(BUILDDIR)/$(pkg).u" "$(DESTDIR)/CookedPCConsole")
+	cp -t "$(DESTDIR)/CookedPCConsole" $(foreach pkg,$(lwce_packages) $(lwce_mods),"$(BUILDDIR)/$(pkg).u")
 	for f in "LWCE_Core/Config"/*; do unix2dos <"$$f" >"$(DESTDIR)/Config/$${f##*/}"; done
 	for f in "LWCE_Core/Localization/INT"/*; do unix2dos <"$$f" >"$(DESTDIR)/Localization/INT/$${f##*/}"; done
 	for f in "LWCE_Core/Patches"/*; do unix2dos <"$$f" >"$(DESTDIR)/UPK patches/$${f##*/}"; done

--- a/flake.nix
+++ b/flake.nix
@@ -92,10 +92,14 @@
           pname = "XCOM-LW-CommunityEdition";
           version = "0.0.1";
           srcs = [
-            (pkgs.lib.cleanSource ./.)
+            (builtins.path {
+              filter = path: type: ! builtins.elem (baseNameOf path) [".git"];
+              path = ./.;
+              name = "lwce_source";
+            })
             packages.udk_wpfx
           ];
-          sourceRoot = "source";
+          sourceRoot = "lwce_source";
           nativeBuildInputs = [pkgs.dos2unix] ++ winedeps;
           preBuild = winesetup {
             pfx = "$PWD/build/wpfx";

--- a/wine_build
+++ b/wine_build
@@ -18,7 +18,8 @@ init_wpfx() {
     wineserver -w
 
     for d in "${udk_srcpath}/"*; do
-        cp -af --reflink=auto "${d}"{,_sample}
+        mv "${d}" "${d}_sample"
+        ln -sT "${d}_sample" "${d}"
     done
 
     mv -f "${engine_conf_in}" "${engine_conf_out}"
@@ -27,18 +28,13 @@ init_wpfx() {
 
 lwce_udk() {
     local udk_srcpath=${1}
-    local stub_dir=${2}
-    local src_dir=${3}
-    local engine_conf_in=${4}
-    local engine_conf_out=${5}
-    shift 5
+    local engine_conf_in=${2}
+    local engine_conf_out=${3}
+    shift 3
 
     for d in "${@}"; do
-        if [[ -d "${stub_dir}/${d}" ]]; then
-            rm -rf "${udk_srcpath:?}/${d}"
-            ln -sfT "$(realpath --relative-to="${udk_srcpath}" "${stub_dir}")/${d}" "${udk_srcpath}/${d}"
-        elif [[ -d "${src_dir}/${d}" ]]; then
-            ln -sfT "$(realpath --relative-to="${udk_srcpath}" "${src_dir}")/${d}" "${udk_srcpath}/${d}"
+        if [[ -d "${d}" ]]; then
+            ln -sft "${udk_srcpath}" "$(realpath --relative-to="${udk_srcpath}" "${d}")"
         else
             echo "Missing package: ${d}" >&2
             exit 1
@@ -46,7 +42,7 @@ lwce_udk() {
     done
 
     sample_config="$(printf '+EditPackages=%s\\r\\n' 'UTGame' 'UTGameContent')"
-    lwce_config="$(printf '+EditPackages=%s\\r\\n' "${@}")"
+    lwce_config="$(printf '+EditPackages=%s\\r\\n' "${@##*/}")"
     sed -z -e "s@${sample_config}@${lwce_config}@g" \
         "${engine_conf_in}" > "${engine_conf_out}"
 }

--- a/wine_build
+++ b/wine_build
@@ -9,6 +9,8 @@ init_wpfx() {
     local engine_conf_out=${4}
     shift 4
 
+    local d
+
     env | grep WINE
     rm -rf "${WINEPREFIX}"
     mkdir -p "${WINEPREFIX}"
@@ -31,6 +33,8 @@ lwce_udk() {
     local engine_conf_in=${2}
     local engine_conf_out=${3}
     shift 3
+
+    local d sample_config lwce_config
 
     for d in "${@}"; do
         if [[ -d "${d}" ]]; then

--- a/wine_build
+++ b/wine_build
@@ -27,18 +27,18 @@ init_wpfx() {
 
 lwce_udk() {
     local udk_srcpath=${1}
-    local src_root=${2}
-    local engine_conf_in=${3}
-    local engine_conf_out=${4}
-    shift 4
+    local stub_dir=${2}
+    local src_dir=${3}
+    local engine_conf_in=${4}
+    local engine_conf_out=${5}
+    shift 5
 
-    relpath=$(echo "${udk_srcpath}" | sed -e "s#^${src_root}/##g" -e 's#[^/]\+#..#g')
     for d in "${@}"; do
-        if [[ -d "${src_root}/Stubs/${d}" ]]; then
+        if [[ -d "${stub_dir}/${d}" ]]; then
             rm -rf "${udk_srcpath:?}/${d}"
-            ln -sfT "${relpath}/Stubs/${d}" "${udk_srcpath}/${d}"
-        elif [[ -d "${src_root}/Src/${d}" ]]; then
-            ln -sfT "${relpath}/Src/${d}" "${udk_srcpath}/${d}"
+            ln -sfT "$(realpath --relative-to="${udk_srcpath}" "${stub_dir}")/${d}" "${udk_srcpath}/${d}"
+        elif [[ -d "${src_dir}/${d}" ]]; then
+            ln -sfT "$(realpath --relative-to="${udk_srcpath}" "${src_dir}")/${d}" "${udk_srcpath}/${d}"
         else
             echo "Missing package: ${d}" >&2
             exit 1


### PR DESCRIPTION
Should now produce exactly the same layout that's needed for the installer:

```
% tree Installer/Resources 
Installer/Resources
├── Config
│   ├── DefaultLWCEBaseStrategyGame.ini
│   ├── DefaultLWCEBaseTacticalGame.ini
│   ├── DefaultLWCEClasses.ini
│   └── DefaultLWCEQualityOfLife.ini
├── CookedPCConsole
│   └── XComLongWarCommunityEdition.u
├── Localization
│   └── INT
│       └── XComLongWarCommunityEdition.int
├── Mods
└── UPK patches

6 directories, 6 files
% make UDK=../UDKInstall-2011-09-BETA.exe install
…
% tree install
install
├── Config
│   ├── DefaultLWCEBaseStrategyGame.ini
│   ├── DefaultLWCEBaseTacticalGame.ini
│   ├── DefaultLWCEClasses.ini
│   └── DefaultLWCEQualityOfLife.ini
├── CookedPCConsole
│   └── XComLongWarCommunityEdition.u
├── Localization
│   └── INT
│       └── XComLongWarCommunityEdition.int
├── README.txt
└── UPK patches
    ├── README.md
    ├── XComGame_Overrides.upatch
    └── XComMutator_Overrides.upatch

5 directories, 10 files
% nix build
…
% tree result 
result
├── Config
│   ├── DefaultLWCEBaseStrategyGame.ini
│   ├── DefaultLWCEBaseTacticalGame.ini
│   ├── DefaultLWCEClasses.ini
│   └── DefaultLWCEQualityOfLife.ini
├── CookedPCConsole
│   └── XComLongWarCommunityEdition.u
├── Localization
│   └── INT
│       └── XComLongWarCommunityEdition.int
├── README.txt
└── UPK patches
    ├── README.md
    ├── XComGame_Overrides.upatch
    └── XComMutator_Overrides.upatch

5 directories, 10 files
```
