### PR TITLE
linux build: Honor gitignore and produce correct install layout

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,7 @@
         url = "https://mcmullin.de/public/games/modding/xcom/udk/UDKInstall-2011-09-BETA.exe";
         sha256 = "sha256-224tDCt4iOcLMCNYqvHgIvC+psnsnNC52p0ejkMEo9c=";
       };
+      lwce_src = pkgs.nix-gitignore.gitignoreSource [] ./.;
 
       winesetup = {
         pfx,
@@ -92,22 +93,18 @@
           pname = "XCOM-LW-CommunityEdition";
           version = "0.0.1";
           srcs = [
-            (builtins.path {
-              filter = path: type: ! builtins.elem (baseNameOf path) [".git"];
-              path = ./.;
-              name = "lwce_source";
-            })
+            lwce_src
             packages.udk_wpfx
           ];
           sourceRoot = ".";
           nativeBuildInputs = [pkgs.dos2unix] ++ winedeps;
           preBuild = winesetup {
-            pfx = "$PWD/lwce_source/build/wpfx";
+            pfx = ''$PWD/$(stripHash "${lwce_src}")/build/wpfx'';
             cmd = ''
               # wine requires that the wineprefix is owned by the current user, so we can't use it from the store path directly
-              mkdir -p lwce_source/build
+              mkdir -p "$(stripHash "${lwce_src}")/build"
               mv -T "$(stripHash "${packages.udk_wpfx}")" "$WINEPREFIX"
-              cd lwce_source
+              cd "$(stripHash "${lwce_src}")"
             '';
           };
           makeFlags = ["UDK=${udk}"];

--- a/flake.nix
+++ b/flake.nix
@@ -99,15 +99,15 @@
             })
             packages.udk_wpfx
           ];
-          sourceRoot = "lwce_source";
+          sourceRoot = ".";
           nativeBuildInputs = [pkgs.dos2unix] ++ winedeps;
           preBuild = winesetup {
-            pfx = "$PWD/build/wpfx";
+            pfx = "$PWD/lwce_source/build/wpfx";
             cmd = ''
               # wine requires that the wineprefix is owned by the current user, so we can't use it from the store path directly
-              mkdir -p build
-              chmod -R u+w "''${PWD%$sourceRoot}/$(stripHash "${packages.udk_wpfx}")"
-              mv "''${PWD%$sourceRoot}/$(stripHash "${packages.udk_wpfx}")" "$WINEPREFIX"
+              mkdir -p lwce_source/build
+              mv -T "$(stripHash "${packages.udk_wpfx}")" "$WINEPREFIX"
+              cd lwce_source
             '';
           };
           makeFlags = ["UDK=${udk}"];


### PR DESCRIPTION
A small refactoring of the nix flake for readability and to honor gitignore and not copy ignored files to the build.

Also, ensure the Makefile produces what I believe is the correct layout for the installer:

```
        % tree install
        install
        ├── Config
        │   ├── DefaultLWCEBaseStrategyGame.ini
        │   ├── DefaultLWCEBaseTacticalGame.ini
        │   ├── DefaultLWCEClasses.ini
        │   └── DefaultLWCEQualityOfLife.ini
        ├── CookedPCConsole
        │   └── XComLongWarCommunityEdition.u
        ├── Localization
        │   └── INT
        │       └── XComLongWarCommunityEdition.int
        ├── Mods
        │   └── LWCEGraphicsPack
        │       ├── Config
        │       │   └── XComLWCEGraphicsPack.ini
        │       └── Script
        │           └── LWCEGraphicsPack.u
        ├── README.txt
        └── UPK patches
            ├── README.md
            ├── XComGame_Overrides.upatch
            └── XComMutator_Overrides.upatch
```