### PR TITLE
Fix flanking sightline indicators after load

### DIFF
--- a/LWCE_Core/Src/XComLongWarCommunityEdition/Classes/LWCETacticalVisibilityHelper.uc
+++ b/LWCE_Core/Src/XComLongWarCommunityEdition/Classes/LWCETacticalVisibilityHelper.uc
@@ -258,6 +258,12 @@ protected function InitializeHelpers()
 
     ConfigureHelperUnit(m_kNonCoverUsingHelper);
     ConfigureHelperUnit(m_kCoverUsingHelper);
+    // This is needed because after loading the helper from a save,
+    // ProcessNewPosition() is called, which makes it stick to cover in the
+    // location where it was saved. Calling ProcessNewPosition(false) again
+    // resets this. Otherwise flanking indicators break.
+    m_kNonCoverUsingHelper.ProcessNewPosition(false);
+    m_kCoverUsingHelper.ProcessNewPosition(false);
 }
 
 protected function ConfigureHelperUnit(XGUnit kUnit)


### PR DESCRIPTION
As mentioned in #34, I saw that the original sightlines mod had a similar call after moving the helper in the past, but it's commented out there.

I tested a bit more and when calling it each time the helper is moved it messes up grenade targeting previews depending on where the helper is when the ability is activated. However, calling it once after the helper is found un-sticks it from whatever cover it was clinging to after the load.

It's probably possible to figure out which flags exactly need to be reset on the helper after loading, but this seems to work.