### PR TITLE
Re-enable LOS flanking previews; add flank color in unit flag, and add separate configurable disc colors

### DIFF
--- a/LWCE_Core/Config/DefaultLWCEQualityOfLife.ini
+++ b/LWCE_Core/Config/DefaultLWCEQualityOfLife.ini
@@ -12,6 +12,12 @@
 bShowInUnitDisc=true
 bShowInUnitFlag=true
 
+; If true, the LOS preview will show whether a position results in a flank on visible enemies. This is shown
+; in both the unit flag (if enabled) and the unit disc (if enabled and flank colors are configured).
+; WARNING: at this time the flank preview is slightly buggy and has a few false positives and negatives,
+; mostly in situations where you are attempting to move to a position immediately next to an enemy.
+bShowFlanks=false
+
 ; Show LoS previews for:
 bShowForEnemyUnits=true     ; enemies
 bShowForFriendlyUnits=true  ; friendlies
@@ -21,8 +27,11 @@ bShowForNeutralUnits=false  ; neutral units; typically this is only civilians on
 ; What color disc to show under units in LoS preview. Choices are
 ; eVDC_None, eVDC_Green, eVDC_Gold, eVDC_Orange, eVDC_Red, and eVDC_White.
 eDiscColorForEnemyUnits=eVDC_None
+eDiscColorForFlankedEnemyUnits=eVDC_None
 eDiscColorForFriendlyUnits=eVDC_None
+eDiscColorForFlankedFriendlyUnits=eVDC_None
 eDiscColorForNeutralUnits=eVDC_None
+eDiscColorForFlankedNeutralUnits=eVDC_None
 
 [XComLongWarCommunityEdition.LWCE_XGFacility_Hangar]
 ; If true, new pilots will automatically receive a nickname without the player having to give them one

--- a/LWCE_Core/Src/XComLongWarCommunityEdition/Classes/LWCE_UIUnitFlag.uc
+++ b/LWCE_Core/Src/XComLongWarCommunityEdition/Classes/LWCE_UIUnitFlag.uc
@@ -20,7 +20,7 @@ simulated function Update(XGUnit kNewActiveUnit)
     super.Update(kNewActiveUnit);
 }
 
-simulated function ToggleVisibilityPreviewIcon(bool bVisible)
+simulated function ToggleVisibilityPreviewIcon(bool bVisible, bool bFlanking)
 {
     local array<ASValue> arrParams;
     local GFxObject gfxUnitFlag;
@@ -69,7 +69,17 @@ simulated function ToggleVisibilityPreviewIcon(bool bVisible)
             class'LWCEUIUtils'.static.SetObjectColorAdd(m_gfxVisibilityPreviewIcon, 180, 180, 180); // grayscale reduction
             break;
         case eTeam_Alien:
-            class'LWCEUIUtils'.static.SetObjectColorMultiply(m_gfxVisibilityPreviewIcon, 230.0 / 255.0, 0, 0); // lighten the red channel a little
+            if (bFlanking)
+            {
+                class'LWCEUIUtils'.static.SetObjectColorMultiply(m_gfxVisibilityPreviewIcon, 0, 0, 0);
+                class'LWCEUIUtils'.static.SetObjectColorAdd(m_gfxVisibilityPreviewIcon, 254, 209, 56);
+            }
+            else
+            {
+                class'LWCEUIUtils'.static.SetObjectColorMultiply(m_gfxVisibilityPreviewIcon, 230.0 / 255.0, 0, 0); // lighten the red channel a little
+                class'LWCEUIUtils'.static.SetObjectColorAdd(m_gfxVisibilityPreviewIcon, 0, 0, 0);
+            }
+
             break;
     }
 


### PR DESCRIPTION
Also addresses a bug which `ProcessNewPosition` by itself doesn't seem to handle on loads, where the tile occupied by the LOS helper at the time the save was made is still occupied post-load. `ProcessNewPosition` takes care of that if the old spot was in cover, but not if it's out in the open.