### PR TITLE
sightline: Don't show indicators for dead units

### DIFF
--- a/LWCE_Core/Src/XComLongWarCommunityEdition/Classes/LWCETacticalVisibilityHelper.uc
+++ b/LWCE_Core/Src/XComLongWarCommunityEdition/Classes/LWCETacticalVisibilityHelper.uc
@@ -438,14 +438,15 @@ protected function SetVisibilityMarkers(XGUnit kActiveUnit, XGUnit kHelper)
         switch (kUnit.GetTeam())
         {
             case eTeam_Alien:
-                bVisible = bShowForEnemyUnits && arrEnemies.Find(kUnit) != INDEX_NONE && kActiveUnit.GetSquad().SquadCanSeeEnemy(kUnit);
+                bVisible = bShowForEnemyUnits && kUnit.IsAliveAndWell() && arrEnemies.Find(kUnit) != INDEX_NONE && kActiveUnit.GetSquad().SquadCanSeeEnemy(kUnit);
                 break;
             case eTeam_Neutral:
                 // TODO: needs extra testing, not sure if neutrals will count as enemies to an XCOM unit
-                bVisible = bShowForNeutralUnits && arrFriends.Find(kUnit) != INDEX_NONE && kActiveUnit.GetSquad().SquadCanSeeEnemy(kUnit);
+                bVisible = bShowForNeutralUnits && kUnit.IsAliveAndWell() && arrFriends.Find(kUnit) != INDEX_NONE && kActiveUnit.GetSquad().SquadCanSeeEnemy(kUnit);
                 break;
             case eTeam_XCom:
-                bVisible = bShowForFriendlyUnits && arrFriends.Find(kUnit) != INDEX_NONE;
+                // IsAlive instead of IsAliveAndWell for bleeding out/stabilized units
+                bVisible = bShowForFriendlyUnits && kUnit.IsAlive() && arrFriends.Find(kUnit) != INDEX_NONE;
                 break;
         }
 


### PR DESCRIPTION
I think we could use `IsAlive` for aliens as well to get sightlines to captured aliens.

The only reasons for that that I could imagine are if they count for Bring 'Em On or Aggression or provide sight to the aliens. But those sound like bugs (haven't actually tested this but wouldn't rule it out).