### PR TITLE
sightlines: Fix helpers getting stuck on wrong tile

### DIFF
--- a/LWCE_Core/Src/XComLongWarCommunityEdition/Classes/LWCETacticalVisibilityHelper.uc
+++ b/LWCE_Core/Src/XComLongWarCommunityEdition/Classes/LWCETacticalVisibilityHelper.uc
@@ -67,6 +67,8 @@ var config EVisDiscColor eDiscColorForEnemyUnits;
 var config EVisDiscColor eDiscColorForFriendlyUnits;
 var config EVisDiscColor eDiscColorForNeutralUnits;
 
+var Vector m_vLastValidCursor;
+var Vector m_vLastValidDestination;
 var protected bool m_bInitialized;
 var protected XGUnit m_kNonCoverUsingHelper;
 var protected XGUnit m_kCoverUsingHelper;
@@ -190,6 +192,10 @@ function UpdateVisibilityMarkers()
     {
         HideAllVisibilityMarkers();
         return;
+    }
+    if (Cursor().Location != m_vLastValidCursor || vDestination != m_vLastValidDestination)
+    {
+        OnCursorMoved();
     }
 
     if (kActiveUnit.CanUseCover())
@@ -379,6 +385,9 @@ protected function OnCursorMoved()
         // Zero vector: don't move the helpers, cursor is not on a valid tile
         return;
     }
+
+    m_vLastValidCursor = Cursor().Location;
+    m_vLastValidDestination = vDestination;
 
     // We just move the helper units, without updating any visibility markers. It
     // will take a few frames for visibility info to fully update.


### PR DESCRIPTION
There are some cases where the sightline helper can get stuck when moving the cursor a single tile. This is most easily reproduced when moving the cursor across blue/yellow move border.

What happens is that `OnCursorMoved` triggers but the path is temporarily invalid as (I think) the movement limit is updated for the yellow move range. Because the path is invalid (i.e. destination 0), the helper is not moved and as long as the cursor is not moved remains in the last tile.

I can imagine this also happening in other cases, e.g. when tiles are blocked/unblocked by fire or explosives but maybe the cursor position stays still or simply when moving to/from/over invalid destinations.