### PR TITLE
Re-enable visibility helper's flanking previews

### DIFF
--- a/LWCE_Core/Config/DefaultLWCEQualityOfLife.ini
+++ b/LWCE_Core/Config/DefaultLWCEQualityOfLife.ini
@@ -12,6 +12,12 @@
 bShowInUnitDisc=true
 bShowInUnitFlag=true
 
+; If true, the LOS preview will show whether a position results in a flank on visible enemies. This is shown
+; in both the unit flag (if enabled) and the unit disc (if enabled and flank colors are configured).
+; WARNING: at this time the flank preview is slightly buggy and has a few false positives and negatives,
+; mostly in situations where you are attempting to move to a position immediately next to an enemy.
+bShowFlanks=true
+
 ; Show LoS previews for:
 bShowForEnemyUnits=true     ; enemies
 bShowForFriendlyUnits=true  ; friendlies
@@ -21,8 +27,11 @@ bShowForNeutralUnits=false  ; neutral units; typically this is only civilians on
 ; What color disc to show under units in LoS preview. Choices are
 ; eVDC_None, eVDC_Green, eVDC_Gold, eVDC_Orange, eVDC_Red, and eVDC_White.
 eDiscColorForEnemyUnits=eVDC_None
+eDiscColorForFlankedEnemyUnits=eVDC_None
 eDiscColorForFriendlyUnits=eVDC_None
+eDiscColorForFlankedFriendlyUnits=eVDC_None
 eDiscColorForNeutralUnits=eVDC_None
+eDiscColorForFlankedNeutralUnits=eVDC_None
 
 [XComLongWarCommunityEdition.LWCE_XGFacility_Hangar]
 ; If true, new pilots will automatically receive a nickname without the player having to give them one

--- a/LWCE_Core/Config/DefaultLWCEQualityOfLife.ini
+++ b/LWCE_Core/Config/DefaultLWCEQualityOfLife.ini
@@ -15,7 +15,8 @@ bShowInUnitFlag=true
 ; If true, the LOS preview will show whether a position results in a flank on visible enemies. This is shown
 ; in both the unit flag (if enabled) and the unit disc (if enabled and flank colors are configured).
 ; WARNING: at this time the flank preview is slightly buggy and has a few false positives and negatives,
-; mostly in situations where you are attempting to move to a position immediately next to an enemy.
+; mostly in situations where you are attempting to move to a position immediately next to an enemy, or when
+; previewing a single-tile move for a soldier.
 bShowFlanks=true
 
 ; Show LoS previews for:
@@ -31,7 +32,6 @@ eDiscColorForFlankedEnemyUnits=eVDC_None
 eDiscColorForFriendlyUnits=eVDC_None
 eDiscColorForFlankedFriendlyUnits=eVDC_None
 eDiscColorForNeutralUnits=eVDC_None
-eDiscColorForFlankedNeutralUnits=eVDC_None
 
 [XComLongWarCommunityEdition.LWCE_XGFacility_Hangar]
 ; If true, new pilots will automatically receive a nickname without the player having to give them one

--- a/LWCE_Core/Src/XComLongWarCommunityEdition/Classes/LWCETacticalVisibilityHelper.uc
+++ b/LWCE_Core/Src/XComLongWarCommunityEdition/Classes/LWCETacticalVisibilityHelper.uc
@@ -71,7 +71,6 @@ var config EVisDiscColor eDiscColorForFlankedEnemyUnits;
 var config EVisDiscColor eDiscColorForFriendlyUnits;
 var config EVisDiscColor eDiscColorForFlankedFriendlyUnits;
 var config EVisDiscColor eDiscColorForNeutralUnits;
-var config EVisDiscColor eDiscColorForFlankedNeutralUnits;
 
 var XGUnit m_kNonCoverUsingHelper;
 var XGUnit m_kCoverUsingHelper;
@@ -154,15 +153,14 @@ simulated event Tick(float fDeltaT)
     // it's an expensive call, so we only call it for one unit, and only after moves. We wait a brief
     // time before making the call so that if the player is quickly moving the mouse around, we aren't
     // stacking up expensive calls and tanking the frame rate.
-    if (m_fTimeUntilProcessPosition > 0.0f)
+    if (m_fTimeUntilProcessPosition > 0.0f && CanSafelyUpdateVisibility())
     {
         m_fTimeUntilProcessPosition -= fDeltaT;
 
         if (m_fTimeUntilProcessPosition <= 0.0f)
         {
             m_kCoverUsingHelper.ProcessNewPosition(false);
-
-            class'XComWorldData'.static.GetWorldData().ClearTileBlockedByUnitFlag(m_kCoverUsingHelper);
+            ClearVisHelperTileClaims();
         }
     }
 
@@ -189,6 +187,8 @@ function MoveHelpersOutOfTheWay()
         vLocation = class'XComWorldData'.static.GetWorldData().FindClosestValidLocation(m_kCoverUsingHelper.Location, /* bAllowFlying */ false, /* bPrioritizeZLevel */ false);
         MoveHelperUnit(m_kCoverUsingHelper, vLocation);
     }
+
+    ClearVisHelperTileClaims();
 }
 
 function UpdateVisibilityMarkers()
@@ -219,11 +219,13 @@ function UpdateVisibilityMarkers()
         return;
     }
 
-    if (Cursor().Location != m_vLastValidCursor || vDestination != m_vLastValidDestination)
+    if (class'Helpers'.static.AreVectorsDifferent(Cursor().Location, m_vLastValidCursor, 0.1f) || class'Helpers'.static.AreVectorsDifferent(vDestination, m_vLastValidDestination, 0.1f))
     {
         OnCursorMoved();
     }
 
+    // We can't tell if the visibility data has actually changed; it's just ready at some point after we move the helper units.
+    // Unfortunately we just have to update the UI pretty often.
     if (kActiveUnit.CanUseCover())
     {
         SetVisibilityMarkers(kActiveUnit, m_kCoverUsingHelper);
@@ -306,10 +308,114 @@ protected function InitializeHelpers()
     // Need to do this to make sure any tile occupied at the time the game was saved is now cleared.
     // This has to come after ProcessNewPosition, for reasons unknown.
     class'XComWorldData'.static.GetWorldData().SetTileBlockedByUnitFlag(m_kNonCoverUsingHelper);
-    class'XComWorldData'.static.GetWorldData().ClearTileBlockedByUnitFlag(m_kNonCoverUsingHelper);
-
     class'XComWorldData'.static.GetWorldData().SetTileBlockedByUnitFlag(m_kCoverUsingHelper);
-    class'XComWorldData'.static.GetWorldData().ClearTileBlockedByUnitFlag(m_kCoverUsingHelper);
+
+    ClearVisHelperTileClaims(/* bForce */ true);
+}
+
+/// <summary>
+/// Checks if the game is in a state where updating visibility data (such as by moving the helper unit, or
+/// updating their cover states) is going to break something.
+/// </summary>
+protected function bool CanSafelyUpdateVisibility()
+{
+    local XGAction kAction;
+    local XGAction_Targeting kTargetingAction;
+    local XGUnit kActiveUnit;
+
+    if (!m_bInitialized)
+    {
+        return false;
+    }
+
+    kActiveUnit = TacticalController().m_kActiveUnit;
+
+    if (kActiveUnit == none)
+    {
+        return true;
+    }
+
+    kAction = kActiveUnit.GetAction();
+
+    if (kAction == none)
+    {
+        return true;
+    }
+
+    kTargetingAction = XGAction_Targeting(kActiveUnit.GetAction());
+
+    if (kTargetingAction != none && kTargetingAction.m_kShot != none && kTargetingAction.m_kShot.IsA('XGAbility_Grapple'))
+    {
+        return true;
+    }
+
+    // XGAction_Path is used when choosing the unit's destination; it's the only action other than targeting a grapple
+    // that we can safely update visibility during. IsPerformingAction does not count it, hence the separate check.
+    if (kAction.IsA('XGAction_Path'))
+    {
+        return true;
+    }
+
+    return false;
+}
+
+/// <summary>
+/// Marks tiles occupied by vis helpers as unoccupied, unless there is an actual unit occupying the same tile.
+/// </summary>
+/// <param name="bForce">If true, tile claims will be modified even if it's not currently safe to do so.</param>
+protected function ClearVisHelperTileClaims(optional bool bForce = false)
+{
+    local bool bClearCoverHelper, bClearNonCoverHelper;
+    local int iCoverHelperX, iCoverHelperY, iCoverHelperZ;
+    local int iNonCoverHelperX, iNonCoverHelperY, iNonCoverHelperZ;
+    local int iUnitX, iUnitY, iUnitZ;
+    local XComWorldData kWorldData;
+    local XGUnit kUnit;
+
+    if (!bForce && !CanSafelyUpdateVisibility())
+    {
+        return;
+    }
+
+    bClearCoverHelper = true;
+    bClearNonCoverHelper = true;
+    kWorldData = class'XComWorldData'.static.GetWorldData();
+
+    kWorldData.GetTileCoordinatesFromPosition(m_kCoverUsingHelper.Location, iCoverHelperX, iCoverHelperY, iCoverHelperZ);
+    kWorldData.GetTileCoordinatesFromPosition(m_kNonCoverUsingHelper.Location, iNonCoverHelperX, iNonCoverHelperY, iNonCoverHelperZ);
+
+    foreach AllActors(class'XGUnit', kUnit)
+    {
+        if (IsVisHelper(kUnit))
+        {
+            continue;
+        }
+
+        kWorldData.GetTileCoordinatesFromPosition(kUnit.Location, iUnitX, iUnitY, iUnitZ);
+
+        // Our vis helpers don't always quite match unit positions on the Z axis, so add a small tolerance in that dimension
+        if (iUnitX == iCoverHelperX && iUnitY == iCoverHelperY && Abs(iUnitZ - iCoverHelperZ) <= 2)
+        {
+            bClearCoverHelper = false;
+        }
+
+        if (iUnitX == iNonCoverHelperX && iUnitY == iNonCoverHelperY && Abs(iUnitZ - iNonCoverHelperZ) <= 2)
+        {
+            bClearNonCoverHelper = false;
+        }
+    }
+
+    if (bClearCoverHelper)
+    {
+        kWorldData.ClearTileBlockedByUnitFlag(m_kCoverUsingHelper);
+        m_kCoverUsingHelper.UnClaimCover();
+    }
+
+    if (bClearNonCoverHelper)
+    {
+        kWorldData.ClearTileBlockedByUnitFlag(m_kNonCoverUsingHelper);
+        m_kNonCoverUsingHelper.UnClaimCover();
+    }
 }
 
 protected function ConfigureHelperUnit(XGUnit kUnit)
@@ -391,19 +497,14 @@ protected function MarkUnit(XGUnit kUnit, bool bVisible, bool bFlanked, bool bIs
 
 protected function MoveHelperUnit(XGUnit kUnit, out Vector vLoc)
 {
-    kUnit.SetLocation(vLoc);
     kUnit.GetPawn().SetLocation(vLoc);
-
-    // Make sure the tile isn't registered as blocked so it doesn't affect nearby units
-    class'XComWorldData'.static.GetWorldData().ClearTileBlockedByUnitFlag(kUnit);
 
     // Need to reset the unit after each move, or else some parts of it become visible again
     ConfigureHelperUnit(kUnit);
 }
 
-protected function OnCursorMoved()
+function OnCursorMoved()
 {
-    local XGUnit kActiveUnit;
     local Vector vDestination;
 
     if (!m_bInitialized)
@@ -411,19 +512,22 @@ protected function OnCursorMoved()
         return;
     }
 
-    kActiveUnit = TacticalController().m_kActiveUnit;
-
-    // Save recomputing visibility data if it's not XCOM's turn
-    if (kActiveUnit == none || kActiveUnit.GetTeam() != eTeam_XCom)
+    // Save recomputing visibility data if not needed
+    if (!CanSafelyUpdateVisibility())
     {
         return;
     }
 
-    vDestination = kActiveUnit.GetPathingPawn().GetPathDestinationLimitedByCost();
+    vDestination = TacticalController().m_kActiveUnit.GetPathingPawn().GetPathDestinationLimitedByCost();
 
     if (VSizeSq(vDestination) == 0.0)
     {
         // Zero vector: don't move the helpers, cursor is not on a valid tile
+        return;
+    }
+
+    if (!class'Helpers'.static.AreVectorsDifferent(Cursor().Location, m_vLastValidCursor, 0.1f) || !class'Helpers'.static.AreVectorsDifferent(vDestination, m_vLastValidDestination, 0.1f))
+    {
         return;
     }
 
@@ -434,6 +538,8 @@ protected function OnCursorMoved()
     // will take a few frames for visibility info to fully update.
     MoveHelperUnit(m_kNonCoverUsingHelper, vDestination);
     MoveHelperUnit(m_kCoverUsingHelper, vDestination);
+
+    ClearVisHelperTileClaims();
 
     // Queue up for position processing later
     m_fTimeUntilProcessPosition = PROCESS_POSITION_DELAY_SECONDS;
@@ -449,7 +555,7 @@ protected function MaterialInterface GetMaterialForUnitDisc(XGUnit kUnit, bool b
             eDiscColor = bFlanked ? eDiscColorForFlankedEnemyUnits : eDiscColorForEnemyUnits;
             break;
         case eTeam_Neutral:
-            eDiscColor = bFlanked ? eDiscColorForFlankedNeutralUnits : eDiscColorForNeutralUnits;
+            eDiscColor = eDiscColorForNeutralUnits;
             break;
         case eTeam_XCom:
             eDiscColor = bFlanked ? eDiscColorForFlankedFriendlyUnits : eDiscColorForFriendlyUnits;
@@ -505,11 +611,11 @@ protected function SetVisibilityMarkers(XGUnit kActiveUnit, XGUnit kHelper)
 
         bFlanked = false;
 
-        if (bVisible && bShowFlanks && kUnit.GetTeam() == eTeam_Alien)
+        if (bVisible && bShowFlanks && kUnit.GetTeam() != eTeam_Neutral)
         {
             // Condition from UISightlineHUD_SightlineContainer
             bFlanked = kUnit.CanUseCover() && !kUnit.IsFlying()
-                 && ( !kUnit.IsInCover() || kUnit.IsFlankedByLoc(kHelper.Location) || kUnit.IsFlankedBy(kHelper) );
+                 && ( !kUnit.IsInCover() || kUnit.IsFlankedByLoc(kHelper.m_kPawn.Location) || kUnit.IsFlankedBy(kHelper) );
         }
 
         MarkUnit(kUnit, bVisible, bFlanked, kUnit == kActiveUnit);
@@ -518,8 +624,6 @@ protected function SetVisibilityMarkers(XGUnit kActiveUnit, XGUnit kHelper)
 
 protected function bool ShouldHideVisibilityMarkers(XGUnit kActiveUnit)
 {
-    local XGAction_Targeting kAction;
-
     if (!m_bInitialized)
     {
         return true;
@@ -535,22 +639,9 @@ protected function bool ShouldHideVisibilityMarkers(XGUnit kActiveUnit)
         return true;
     }
 
-    if (kActiveUnit.IsPerformingAction())
-    {
-        kAction = XGAction_Targeting(kActiveUnit.GetAction());
-
-        if (kAction != none)
-        {
-            if (kAction.m_kShot != none && kAction.m_kShot.IsA('XGAbility_Grapple'))
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    return false;
+    // Hide vis markers any time it's not safe to update them; this makes sense for most abiliites
+    // (e.g. no need for vis markers when targeting a grenade) and also prevents showing stale data
+    return !CanSafelyUpdateVisibility();
 }
 
 protected function XGUnit SpawnHelperUnit(EPawnType eType)

--- a/LWCE_Core/Src/XComLongWarCommunityEdition/Classes/LWCETacticalVisibilityHelper.uc
+++ b/LWCE_Core/Src/XComLongWarCommunityEdition/Classes/LWCETacticalVisibilityHelper.uc
@@ -72,8 +72,8 @@ var config EVisDiscColor eDiscColorForFriendlyUnits;
 var config EVisDiscColor eDiscColorForFlankedFriendlyUnits;
 var config EVisDiscColor eDiscColorForNeutralUnits;
 
-var XGUnit m_kNonCoverUsingHelper;
-var XGUnit m_kCoverUsingHelper;
+var protected XGUnit m_kNonCoverUsingHelper;
+var protected XGUnit m_kCoverUsingHelper;
 
 var protected Vector m_vLastValidCursor;
 var protected Vector m_vLastValidDestination;

--- a/LWCE_Core/Src/XComLongWarCommunityEdition/Classes/LWCETacticalVisibilityHelper.uc
+++ b/LWCE_Core/Src/XComLongWarCommunityEdition/Classes/LWCETacticalVisibilityHelper.uc
@@ -161,6 +161,8 @@ simulated event Tick(float fDeltaT)
         if (m_fTimeUntilProcessPosition <= 0.0f)
         {
             m_kCoverUsingHelper.ProcessNewPosition(false);
+
+            class'XComWorldData'.static.GetWorldData().ClearTileBlockedByUnitFlag(m_kCoverUsingHelper);
         }
     }
 

--- a/LWCE_Core/Src/XComLongWarCommunityEdition/Classes/LWCEUIUtils.uc
+++ b/LWCE_Core/Src/XComLongWarCommunityEdition/Classes/LWCEUIUtils.uc
@@ -3,6 +3,9 @@
 // forming HTML strings.
 class LWCEUIUtils extends Object;
 
+var Color FlankColor;
+var Color XComLightColor;
+
 static function bool TryGetPanelReference(UI_FxsPanel kPanel, out GFxObject gfxRef)
 {
     gfxRef = kPanel.manager.GetVariableObject(string(kPanel.GetMCPath()));
@@ -106,6 +109,21 @@ static function SetObjectColorAdd(GFxObject gfxObj, int Red, int Green, int Blue
 }
 
 /// <summary>
+/// Identical to SetObjectColorAdd, but using a struct.
+/// </summary>
+static function SetObjectColorAddFromStruct(GFxObject gfxObj, const out Color kColor, optional bool bUseAlpha = false)
+{
+    if (bUseAlpha)
+    {
+        SetObjectColorAdd(gfxObj, kColor.R, kColor.G, kColor.B, kColor.A);
+    }
+    else
+    {
+        SetObjectColorAdd(gfxObj, kColor.R, kColor.G, kColor.B);
+    }
+}
+
+/// <summary>
 /// Sets the object's multiplicative color transform. The multiplier for each channel can be any value.
 /// The final value for each channel is computed as (origValue * multiplier) + offset, clamped to
 /// the range [0, 255].
@@ -161,4 +179,10 @@ protected static function GfxObject AS_BindMovie(GFxObject kOwner, coerce string
 protected static function UIInterfaceMgr GetHUD()
 {
     return XComPlayerController(class'Engine'.static.GetCurrentWorldInfo().GetALocalPlayerController()).m_Pres.GetHUD();
+}
+
+defaultproperties
+{
+    FlankColor=(R=254, G=209, B=56, A=255)
+    XComLightColor=(R=103, G=232, B=237, A=255)
 }

--- a/LWCE_Core/Src/XComLongWarCommunityEdition/Classes/LWCE_UIUnitFlag.uc
+++ b/LWCE_Core/Src/XComLongWarCommunityEdition/Classes/LWCE_UIUnitFlag.uc
@@ -54,9 +54,16 @@ simulated function ToggleVisibilityPreviewIcon(bool bVisible, bool bFlanking)
     switch (m_kUnit.GetTeam())
     {
         case eTeam_XCom:
-            // Wipe out the original colors and replace with XCOM's
-            class'LWCEUIUtils'.static.SetObjectColorMultiply(m_gfxVisibilityPreviewIcon, 0, 0, 0);
-            class'LWCEUIUtils'.static.SetObjectColorAdd(m_gfxVisibilityPreviewIcon, 103, 232, 237);
+            if (bFlanking)
+            {
+                class'LWCEUIUtils'.static.SetObjectColorMultiply(m_gfxVisibilityPreviewIcon, 0, 0, 0);
+                class'LWCEUIUtils'.static.SetObjectColorAddFromStruct(m_gfxVisibilityPreviewIcon, class'LWCEUIUtils'.default.FlankColor);
+            }
+            else
+            {
+                class'LWCEUIUtils'.static.SetObjectColorMultiply(m_gfxVisibilityPreviewIcon, 0, 0, 0);
+                class'LWCEUIUtils'.static.SetObjectColorAddFromStruct(m_gfxVisibilityPreviewIcon, class'LWCEUIUtils'.default.XComLightColor);
+            }
 
             // Unit flags for inactive XCOM soldiers are set to 30% alpha; we need to counter that by
             // setting our own icon to absurdly high alpha that cancels out
@@ -72,7 +79,7 @@ simulated function ToggleVisibilityPreviewIcon(bool bVisible, bool bFlanking)
             if (bFlanking)
             {
                 class'LWCEUIUtils'.static.SetObjectColorMultiply(m_gfxVisibilityPreviewIcon, 0, 0, 0);
-                class'LWCEUIUtils'.static.SetObjectColorAdd(m_gfxVisibilityPreviewIcon, 254, 209, 56);
+                class'LWCEUIUtils'.static.SetObjectColorAddFromStruct(m_gfxVisibilityPreviewIcon, class'LWCEUIUtils'.default.FlankColor);
             }
             else
             {

--- a/LWCE_Core/Src/XComLongWarCommunityEdition/Classes/LWCE_UIUnitFlag.uc
+++ b/LWCE_Core/Src/XComLongWarCommunityEdition/Classes/LWCE_UIUnitFlag.uc
@@ -20,7 +20,7 @@ simulated function Update(XGUnit kNewActiveUnit)
     super.Update(kNewActiveUnit);
 }
 
-simulated function ToggleVisibilityPreviewIcon(bool bVisible)
+simulated function ToggleVisibilityPreviewIcon(bool bVisible, bool bFlanking)
 {
     local array<ASValue> arrParams;
     local GFxObject gfxUnitFlag;
@@ -69,7 +69,17 @@ simulated function ToggleVisibilityPreviewIcon(bool bVisible)
             class'LWCEUIUtils'.static.SetObjectColorAdd(m_gfxVisibilityPreviewIcon, 180, 180, 180); // grayscale reduction
             break;
         case eTeam_Alien:
-            class'LWCEUIUtils'.static.SetObjectColorMultiply(m_gfxVisibilityPreviewIcon, 230.0 / 255.0, 0, 0); // lighten the red channel a little
+            if (bFlanking)
+            {
+                class'LWCEUIUtils'.static.SetObjectColorMultiply(m_gfxVisibilityPreviewIcon, 0, 0, 0);
+                class'LWCEUIUtils'.static.SetObjectColorAdd(m_gfxVisibilityPreviewIcon, 254, 209, 56);
+            }
+            else
+            {
+                class'LWCEUIUtils'.static.SetObjectColorMultiply(m_gfxVisibilityPreviewIcon, 230.0 / 255.0, 0, 0); // lighten the red channel a little
+                class'LWCEUIUtils'.static.SetObjectColorAdd(m_gfxVisibilityPreviewIcon, 0, 0, 0);
+            }
+
             break;
     }
 

--- a/Stubs/XComGame/Classes/Helpers.uc
+++ b/Stubs/XComGame/Classes/Helpers.uc
@@ -1,0 +1,34 @@
+class Helpers extends Object
+    abstract
+    native;
+
+struct native ProjectPathPredictionPoint
+{
+    var transient float Time;
+    var transient Vector Location;
+    var transient Vector Velocity;
+};
+
+struct native CamCageResult
+{
+    var int iCamZoneID;
+    var int iCamZoneBlocked;
+};
+
+native static final function float S_EvalInterpCurveFloat(const out InterpCurveFloat Curve, float AlphaValue);
+static function BetterInvoke(){}
+native static final function GetComplexViewOrientation(ScriptSceneView SceneView, Vector PrimaryAimPos, Vector SecondaryAimPos, Rotator EndRotation, out Vector out_Location, out Rotator out_Rotation);
+native static final function Rotator RotateLocalByWorld(Rotator Local, Rotator ByWorld);
+native static final function SetParticleGameSpeed(float TimeScale);
+native static final function PredictProjectilePath(Vector StartLocation, Vector StartVelocity, float Gravity, float BounceFactor, float TotalTime, int NumberOfSteps, out array<ProjectPathPredictionPoint> PredictedPositions, optional float DisableGravityAtZSpeed = 32.0, optional bool bDrawLines = false);
+native static final function bool isVisibilityBlocked(Vector vFrom, Vector vTo, Actor SourceActor, out Vector vHitLoc, optional bool bVolumesOnly = false);
+static simulated function bool isOnScreen(Vector vTarget, TPOV kPOV, float fAspectRatio){}
+native static final function WorldInfo GetWorldInfo();
+static final function OutputMsg(string msg, optional name logCategory){}
+static final function Vector GetMovementData(InterpData MatineeData, int iUnitIdx, optional bool bGetPos, optional int iKeyFrame){}
+static final function float GetPercentageToCameraView(XComTacticalController kTacticalController, XGCameraView kStartingView, XGCameraView kEndingView){}
+native static simulated function SetGameRenderingEnabled(bool Enabled, int iFrameDelay);
+native static final function int NextAbilityID();
+native static function Vector2D GetUVCoords(StaticMeshComponent MeshComp, Vector vWorldStartPos, Vector vWorldDirection);
+native static final function bool AreVectorsDifferent(const out Vector v1, const out Vector v2, float fTolerance);
+native static final function string NetGetVerifyPackageHashes();


### PR DESCRIPTION
This change covers:

* Adding configuration to enable flank previews
* Supporting new colors in unit discs and unit flag for flanks; disc colors are configurable also
* Improving performance of flanking indicators to avoid large FPS drops
* Fixing a vis helper bug which could leave some tiles still blocked on loading a save