### PR TITLE
Issue #59 - Add configuration options for how hit chance against civilians is calculated

### DIFF
--- a/LWCE_Core/Config/DefaultLWCEBaseTacticalGame.ini
+++ b/LWCE_Core/Config/DefaultLWCEBaseTacticalGame.ini
@@ -15,6 +15,14 @@
 ;                 General config                  ;
 ; ; ; ; ; ; ; ; ; ; ; ; ; ; ; ; ; ; ; ; ; ; ; ; ; ;
 
+; How hit chance is calculated against civilians during terror missions. Options are:
+;
+; eHCCS_AlwaysHit        - 100% chance to hit no matter what.
+; eHCCS_CivilianBaseGame - 100% chance to hit, but with a base game bug included where suppression can still lower this hit chance (but nothing else can).
+; eHCCS_NeverHit         - 0% chance to hit no matter what. May not work against melee attacks, and enemy AI may not understand their shots can't hit.
+; eHCCS_Normal           - Normal hit chance calculations that are used for XCOM and aliens.
+eCivilianHitChanceCalcStyle=eHCCS_CivilianBaseGame
+
 ; How much DR is given by low/high cover. This bonus is granted twice if the unit is hunkered or is affected by
 ; Fortiores Una (three times if both).
 fLowCoverDRBonus=0.667

--- a/LWCE_Core/Src/XComLongWarCommunityEdition/Classes/LWCE_XGTacticalGameCore.uc
+++ b/LWCE_Core/Src/XComLongWarCommunityEdition/Classes/LWCE_XGTacticalGameCore.uc
@@ -2,11 +2,29 @@ class LWCE_XGTacticalGameCore extends XGTacticalGameCore
     config(LWCEBaseTacticalGame)
     dependson(LWCETypes);
 
+enum EHitChanceCalcStyle
+{
+    // 100% chance to hit, no matter what.
+    eHCCS_AlwaysHit,
+
+    // Hit chance calculated the same way chances are calculated against civilians in LW 1.0:
+    // 100% chance to hit, modified only by suppression (due to a bug).
+    eHCCS_CivilianBaseGame,
+
+    // 0% chance to hit, no matter what.
+    eHCCS_NeverHit,
+
+    // Normal hit chance calculation
+    eHCCS_Normal
+};
+
 var config array<LWCE_TWeapon> arrCfgWeapons;
 
 // ----------------------------------------
 // Config for tactical game abilities
 // ----------------------------------------
+
+var config EHitChanceCalcStyle eCivilianHitChanceCalcStyle;
 
 // Config that mostly impact the player's units, or aliens and XCOM equally
 var config float fAbsorptionFieldsActivationThreshold;


### PR DESCRIPTION
I tested out the bugged version (equivalent to the new `HCCS_Normal` option) and found it's actually kind of fun, though unbalanced by default. Seemed worth making it an option.